### PR TITLE
Basic HTTP authorisation support

### DIFF
--- a/lib/ews.js
+++ b/lib/ews.js
@@ -55,6 +55,10 @@ function EWS(username, password, host, options) {
     }
   };
 
+  // make the basic authentication header
+  // it gets passed in as an option to soap, as the wsdl file needs to be fetched
+  // using an authenticated requests
+  
   var basicAuth = "Basic " + new Buffer(username + ":" + password).toString("base64");
   this.basic = {
     wsdlOptions: {  wsdl_headers: {Authorization: basicAuth} },

--- a/lib/ews.js
+++ b/lib/ews.js
@@ -5,6 +5,8 @@ var ntlm = require('httpntlm');
 var soap = require('soap');
 var _ = require('lodash');
 
+var httpreq = require('httpreq');
+
 var path = require('path');
 var tmp = require('tmp');
 var fs = require('fs');
@@ -50,6 +52,30 @@ function EWS(username, password, host, options) {
           });
         });
       });
+    }
+  };
+
+  var basicAuth = "Basic " + new Buffer(username + ":" + password).toString("base64");
+  this.basic = {
+    wsdlOptions: {  wsdl_headers: {Authorization: basicAuth} },
+    authProfile: new soap.BasicAuthSecurity(username,password),
+    getFile: function(url, filePath) {
+      return when.promise((resolve, reject) => {
+        httpreq.get(url,
+          {
+            headers:{
+              'Authorization': basicAuth
+            }
+          },
+          function (err, res) {
+          if(err) reject(err);
+          else if(res.statusCode == 401) reject(new Error('Basic StatusCode 401: Unauthorized.'));
+          else fs.writeFile(filePath, res.body, function(err) {
+            if(err) reject(err);
+            else resolve(filePath);
+          });
+        });
+      })
     }
   };
 
@@ -197,6 +223,7 @@ EWS.prototype.run = function(ewsFunction, ewsArgs, soapHeader) {
   var authProfile = this[this.auth].authProfile;
   var wsdlOptions = this[this.auth].wsdlOptions;
 
+
   if(typeof ewsFunction !== 'string' || typeof ewsArgs !== 'object') {
     throw new Error('missing required parameters');
   }
@@ -204,7 +231,6 @@ EWS.prototype.run = function(ewsFunction, ewsArgs, soapHeader) {
   return this.init()
     .then(wsdlFilePath => {
       return when.promise((resolve, reject) => {
-
       //create soap client
       soap.createClient(wsdlFilePath, wsdlOptions, (err, client) => {
         if(err) reject(err);
@@ -217,6 +243,7 @@ EWS.prototype.run = function(ewsFunction, ewsArgs, soapHeader) {
           }
 
           // define security plugin
+
           client.setSecurity(authProfile);
 
           // add optional soap header


### PR DESCRIPTION
I added Basic HTTP authorisation which I have tested successfully against Office 365.

Two issues, I make use of httpreq which is in node_modules as an existing dependency, not sure if this should be made specific?

Also, to keep the constructor interface the same, the authentication defaults to NTLM still, and I set it to Basic like this:

`var ews = new EWS(username, password, host);
ews.auth = 'basic';
`